### PR TITLE
Fix Windows toolbar requiring multiple clicks to interact

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/main.kt
@@ -1,12 +1,22 @@
 package com.knapsack.fixtool
 
+import androidx.compose.foundation.focusable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
 import com.knapsack.fixtool.ui.App
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.slf4j.LoggerFactory
+import java.awt.event.WindowAdapter
+import java.awt.event.WindowEvent
 import java.io.File
 
 fun main() {
@@ -40,7 +50,30 @@ fun main() {
             state = WindowState(size = DpSize(1920.dp, 1080.dp)),
             resizable = true,
         ) {
-            App()
+            val focusRequester = remember { FocusRequester() }
+
+            // Fix for Compose Multiplatform issue #4803: Window focus requires multiple clicks
+            // When window gains focus, automatically request focus on compose content
+            // This prevents users from having to click multiple times on toolbar buttons
+            LaunchedEffect(Unit) {
+                val window = java.awt.Window.getWindows().firstOrNull()
+                window?.addWindowListener(object : WindowAdapter() {
+                    override fun windowActivated(e: WindowEvent?) {
+                        try {
+                            focusRequester.requestFocus()
+                            // Additional delayed focus request for reliability on Windows/Mac
+                            launch {
+                                delay(100)
+                                focusRequester.requestFocus()
+                            }
+                        } catch (e: IllegalStateException) {
+                            // Ignore if focus requester is not yet initialized
+                        }
+                    }
+                })
+            }
+
+            App(modifier = Modifier.focusRequester(focusRequester).focusable())
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
@@ -38,7 +38,7 @@ private val DarkColorScheme =
 
 @Composable
 @Preview
-fun App() {
+fun App(modifier: Modifier = Modifier) {
     MaterialTheme(
         colorScheme = DarkColorScheme,
     ) {
@@ -70,7 +70,7 @@ fun App() {
         } // Message editor panel width (28% when description shown, 20% when hidden) - starts at 28% since description is visible by default
         var connectionPanelSplitRatio by remember { mutableStateOf(0.2f) }
 
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = modifier.fillMaxSize()) {
             Column(
                 modifier =
                     Modifier


### PR DESCRIPTION
Resolves issue where users had to click toolbar buttons 3 times on Windows when the window was out of focus (1st click to activate window, 2nd to focus content, 3rd to trigger button).