### PR TITLE
Make message colors configurable via settings

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/AppSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/AppSettings.kt
@@ -19,6 +19,8 @@ data class AppSettings(
     // Protocol Tags Settings
     val hideProtocolTagsByDefault: Boolean = true, // Hide protocol tags by default in message details
     val protocolTags: Set<Int> = defaultProtocolTags, // List of FIX tags considered as protocol tags
+    // Message Color Scheme
+    val messageColorScheme: MessageColorScheme = MessageColorScheme.default(),
     // Future settings can be added here
     // val theme: String = "dark",
     // val fontSize: Int = 12,

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/MessageColorScheme.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/MessageColorScheme.kt
@@ -1,0 +1,75 @@
+package com.knapsack.fixtool.model
+
+import androidx.compose.ui.graphics.Color
+import kotlinx.serialization.Serializable
+
+/**
+ * Defines a color scheme for FIX messages based on direction and message type.
+ * Colors are specified as ARGB hex values (0xAARRGGBB format).
+ */
+@Serializable
+data class MessageColorScheme(
+    // Outgoing messages (sent from client)
+    val outgoingBright: Long = 0xFF569CD6, // Blue - bright variant for odd rows
+    val outgoingDull: Long = 0xFF4A7DAF, // Blue - dull variant for even rows
+
+    // Incoming messages (received from server)
+    val incomingBright: Long = 0xFF4EC9B0, // Teal/Cyan - bright variant for odd rows
+    val incomingDull: Long = 0xFF3DA89F, // Teal/Cyan - dull variant for even rows
+
+    // Rejection/Logout messages (special case for incoming)
+    val rejectionBright: Long = 0xFFE06C75, // Red - bright variant for odd rows
+    val rejectionDull: Long = 0xFFC55A64, // Red - dull variant for even rows
+) {
+    /**
+     * Convert stored Long color value to Compose Color
+     */
+    fun getOutgoingColor(isBright: Boolean): Color =
+        Color(if (isBright) outgoingBright else outgoingDull)
+
+    fun getIncomingColor(isBright: Boolean): Color =
+        Color(if (isBright) incomingBright else incomingDull)
+
+    fun getRejectionColor(isBright: Boolean): Color =
+        Color(if (isBright) rejectionBright else rejectionDull)
+
+    /**
+     * Get message color based on direction and rejection status
+     */
+    fun getMessageColor(direction: FixMessage.Direction, isRejection: Boolean, isBright: Boolean): Color =
+        when {
+            isRejection -> getRejectionColor(isBright)
+            direction == FixMessage.Direction.OUTGOING -> getOutgoingColor(isBright)
+            else -> getIncomingColor(isBright)
+        }
+
+    companion object {
+        /**
+         * Default color scheme matching the original hardcoded colors
+         */
+        fun default(): MessageColorScheme = MessageColorScheme()
+
+        /**
+         * Alternative color scheme examples
+         */
+        fun greenRed(): MessageColorScheme =
+            MessageColorScheme(
+                outgoingBright = 0xFF98C379, // Green
+                outgoingDull = 0xFF7AA862,
+                incomingBright = 0xFF569CD6, // Blue
+                incomingDull = 0xFF4A7DAF,
+                rejectionBright = 0xFFE06C75, // Red (same)
+                rejectionDull = 0xFFC55A64,
+            )
+
+        fun monochrome(): MessageColorScheme =
+            MessageColorScheme(
+                outgoingBright = 0xFF87CEEB, // Light blue - terminal-style outgoing
+                outgoingDull = 0xFF6FA8C8, // Duller light blue
+                incomingBright = 0xFFC0C0C0, // Light gray - for incoming
+                incomingDull = 0xFFA0A0A0, // Medium-light gray - dull variant
+                rejectionBright = 0xFFE06C75, // Red (same)
+                rejectionDull = 0xFFC55A64,
+            )
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/FixMessageDisplay.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/FixMessageDisplay.kt
@@ -467,6 +467,7 @@ private fun MessageDisplayContent(
                                         } else {
                                             -1
                                         },
+                                    appSettings = appSettings,
                                 )
                             }
                         }
@@ -553,6 +554,9 @@ private fun MessageRow(
     searchQuery: String = "",
     messageMatches: List<Pair<Int, Int>> = emptyList(),
     currentMatchOffset: Int = -1,
+    appSettings: com.knapsack.fixtool.model.AppSettings =
+        com.knapsack.fixtool.model.AppSettings
+            .default(),
 ) {
     // Special handling for separator/blank lines
     when (message) {
@@ -589,7 +593,7 @@ private fun MessageRow(
         }
 
         is FixMessage -> {
-            val textColor = getMessageTextColor(message, messageIndex)
+            val textColor = getMessageTextColor(message, messageIndex, appSettings)
             val backgroundColor = if (isSelected) selectedBackgroundColor else Color.Transparent
             val interactionSource = remember { MutableInteractionSource() }
             val isHovered by interactionSource.collectIsHoveredAsState()
@@ -857,16 +861,12 @@ private val smallIconSize = 14.dp
 private fun getMessageTextColor(
     message: FixMessage,
     messageIndex: Int,
+    appSettings: com.knapsack.fixtool.model.AppSettings,
 ): Color {
     val isBright = messageIndex % 2 == 1
-    return if (message.isRejectionOrLogout()) {
-        if (isBright) rejectionBrightColor else rejectionDullColor
-    } else {
-        when (message.direction) {
-            FixMessage.Direction.INCOMING ->
-                if (isBright) incomingBrightColor else incomingDullColor
-            FixMessage.Direction.OUTGOING ->
-                if (isBright) outgoingBrightColor else outgoingDullColor
-        }
-    }
+    return appSettings.messageColorScheme.getMessageColor(
+        message.direction,
+        message.isRejectionOrLogout(),
+        isBright
+    )
 }

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/HierarchicalGridView.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/HierarchicalGridView.kt
@@ -231,6 +231,7 @@ fun HierarchicalGridView(
                                     expandedMessages[messageId] = !isExpanded
                                 },
                                 onSelectMessage = onSelectMessage,
+                                appSettings = appSettings,
                             )
                         }
 
@@ -265,6 +266,9 @@ fun MessageSummaryRow(
     isSelected: Boolean = false,
     onToggleExpand: () -> Unit,
     onSelectMessage: ((FixMessage?) -> Unit)? = null,
+    appSettings: com.knapsack.fixtool.model.AppSettings =
+        com.knapsack.fixtool.model.AppSettings
+            .default(),
 ) {
     // Extract top-level field values (excluding repeating groups)
     val columnValues =
@@ -274,7 +278,7 @@ fun MessageSummaryRow(
             }
         }
     // Match session coloring: blue for outgoing, red for incoming rejects, green for other incoming
-    val directionColor = getDirectionColor(message)
+    val directionColor = getDirectionColor(message, appSettings)
 
     val timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
     val msgTypeDesc = dictionary.getFieldValueDescription(35, message.messageType) ?: message.messageType
@@ -1043,9 +1047,9 @@ private val tooltipCornerRadius = RoundedCornerShape(4.dp)
 private val iconSize = 14.dp
 
 // Helper function for direction color
-private fun getDirectionColor(message: FixMessage): Color =
-    when (message.direction) {
-        FixMessage.Direction.OUTGOING -> outgoingColor
-        FixMessage.Direction.INCOMING ->
-            if (message.isRejectionOrLogout()) rejectionColor else incomingColor
-    }
+private fun getDirectionColor(message: FixMessage, appSettings: com.knapsack.fixtool.model.AppSettings): Color =
+    appSettings.messageColorScheme.getMessageColor(
+        message.direction,
+        message.isRejectionOrLogout(),
+        true
+    )

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/MessageDetailPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/MessageDetailPanel.kt
@@ -205,7 +205,7 @@ fun MessageDetailPanel(
                                 .padding(12.dp),
                     ) {
                         // Match session coloring: blue for outgoing, red for incoming rejects, green for other incoming
-                        val (directionColor, directionText) = getDirectionInfo(message)
+                        val (directionColor, directionText) = getDirectionInfo(message, appSettings)
 
                         Text(
                             text = directionText,
@@ -974,13 +974,18 @@ private val searchPlaceholderStyle =
 private fun getSearchBorderColor(isFocused: Boolean): Color =
     if (isFocused) focusedBorderColor else unfocusedBorderColor
 
-private fun getDirectionInfo(message: FixMessage): Pair<Color, String> =
+private fun getDirectionInfo(message: FixMessage, appSettings: com.knapsack.fixtool.model.AppSettings): Pair<Color, String> =
     when (message.direction) {
         FixMessage.Direction.INCOMING ->
-            if (message.isRejectionOrLogout()) {
-                rejectionMessageColor to "INCOMING"
-            } else {
-                incomingMessageColor to "INCOMING"
-            }
-        FixMessage.Direction.OUTGOING -> outgoingMessageColor to "OUTGOING"
+            appSettings.messageColorScheme.getMessageColor(
+                message.direction,
+                message.isRejectionOrLogout(),
+                true
+            ) to "INCOMING"
+        FixMessage.Direction.OUTGOING ->
+            appSettings.messageColorScheme.getMessageColor(
+                message.direction,
+                false,
+                true
+            ) to "OUTGOING"
     }

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SettingsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SettingsDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.knapsack.fixtool.model.AppSettings
 import com.knapsack.fixtool.model.FixDictionary
+import com.knapsack.fixtool.model.MessageColorScheme
 import java.io.File
 import javax.swing.JFileChooser
 import javax.swing.filechooser.FileNameExtensionFilter
@@ -45,6 +46,7 @@ fun SettingsDialog(
     var gridViewColumns by remember { mutableStateOf(currentSettings.gridViewColumns.toMutableList()) }
     var hideProtocolTagsByDefault by remember { mutableStateOf(currentSettings.hideProtocolTagsByDefault) }
     var protocolTags by remember { mutableStateOf(currentSettings.protocolTags.toMutableSet()) }
+    var messageColorScheme by remember { mutableStateOf(currentSettings.messageColorScheme) }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -97,6 +99,7 @@ fun SettingsDialog(
                                 gridViewColumns = defaults.gridViewColumns.toMutableList()
                                 hideProtocolTagsByDefault = defaults.hideProtocolTagsByDefault
                                 protocolTags = defaults.protocolTags.toMutableSet()
+                                messageColorScheme = defaults.messageColorScheme
                             },
                             containerColor = restoreDefaultsButtonColor,
                             contentColor = AppTheme.Colors.textSecondary,
@@ -581,6 +584,136 @@ fun SettingsDialog(
                         thickness = AppTheme.Separators.dividerThickness,
                         modifier = Modifier.padding(vertical = AppTheme.Spacing.small),
                     )
+
+                    // Section: Message Color Scheme
+                    Text(
+                        text = "Message Color Scheme",
+                        fontSize = 14.sp,
+                        color = AppTheme.Colors.textSecondary,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+
+                    Text(
+                        text = "Choose color scheme for message display based on direction and type",
+                        fontSize = 11.sp,
+                        color = AppTheme.Colors.textDisabled,
+                        modifier = Modifier.padding(bottom = 8.dp),
+                    )
+
+                    // Preset buttons in a row
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        // Default scheme button
+                        Box(
+                            modifier = Modifier
+                                .height(32.dp)
+                                .weight(1f)
+                                .background(
+                                    color = if (messageColorScheme == MessageColorScheme.default()) AppTheme.Colors.primary else AppTheme.Colors.surface,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .border(
+                                    width = 1.dp,
+                                    color = if (messageColorScheme == MessageColorScheme.default()) AppTheme.Colors.primary else AppTheme.Separators.color,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .clickable { messageColorScheme = MessageColorScheme.default() },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = "Default",
+                                    fontSize = 11.sp,
+                                    color = if (messageColorScheme == MessageColorScheme.default()) AppTheme.Colors.background else AppTheme.Colors.text
+                                )
+                                // Color preview boxes
+                                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                                    Box(Modifier.size(12.dp).background(Color(0xFF569CD6), RoundedCornerShape(2.dp))) // Outgoing
+                                    Box(Modifier.size(12.dp).background(Color(0xFF4EC9B0), RoundedCornerShape(2.dp))) // Incoming
+                                    Box(Modifier.size(12.dp).background(Color(0xFFE06C75), RoundedCornerShape(2.dp))) // Rejection
+                                }
+                            }
+                        }
+
+                        // Green/Red scheme button
+                        Box(
+                            modifier = Modifier
+                                .height(32.dp)
+                                .weight(1f)
+                                .background(
+                                    color = if (messageColorScheme == MessageColorScheme.greenRed()) AppTheme.Colors.primary else AppTheme.Colors.surface,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .border(
+                                    width = 1.dp,
+                                    color = if (messageColorScheme == MessageColorScheme.greenRed()) AppTheme.Colors.primary else AppTheme.Separators.color,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .clickable { messageColorScheme = MessageColorScheme.greenRed() },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = "Green/Red",
+                                    fontSize = 11.sp,
+                                    color = if (messageColorScheme == MessageColorScheme.greenRed()) AppTheme.Colors.background else AppTheme.Colors.text
+                                )
+                                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                                    Box(Modifier.size(12.dp).background(Color(0xFF98C379), RoundedCornerShape(2.dp))) // Outgoing
+                                    Box(Modifier.size(12.dp).background(Color(0xFF569CD6), RoundedCornerShape(2.dp))) // Incoming
+                                    Box(Modifier.size(12.dp).background(Color(0xFFE06C75), RoundedCornerShape(2.dp))) // Rejection
+                                }
+                            }
+                        }
+
+                        // Monochrome scheme button
+                        Box(
+                            modifier = Modifier
+                                .height(32.dp)
+                                .weight(1f)
+                                .background(
+                                    color = if (messageColorScheme == MessageColorScheme.monochrome()) AppTheme.Colors.primary else AppTheme.Colors.surface,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .border(
+                                    width = 1.dp,
+                                    color = if (messageColorScheme == MessageColorScheme.monochrome()) AppTheme.Colors.primary else AppTheme.Separators.color,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .clickable { messageColorScheme = MessageColorScheme.monochrome() },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = "Monochrome",
+                                    fontSize = 11.sp,
+                                    color = if (messageColorScheme == MessageColorScheme.monochrome()) AppTheme.Colors.background else AppTheme.Colors.text
+                                )
+                                Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+                                    Box(Modifier.size(12.dp).background(Color(0xFF87CEEB), RoundedCornerShape(2.dp))) // Outgoing
+                                    Box(Modifier.size(12.dp).background(Color(0xFFC0C0C0), RoundedCornerShape(2.dp))) // Incoming
+                                    Box(Modifier.size(12.dp).background(Color(0xFFE06C75), RoundedCornerShape(2.dp))) // Rejection
+                                }
+                            }
+                        }
+                    }
+
+                    HorizontalDivider(
+                        color = AppTheme.Separators.color,
+                        thickness = AppTheme.Separators.dividerThickness,
+                        modifier = Modifier.padding(vertical = AppTheme.Spacing.small),
+                    )
                 }
 
                 HorizontalDivider(color = AppTheme.Separators.color, thickness = AppTheme.Separators.dividerThickness)
@@ -616,6 +749,7 @@ fun SettingsDialog(
                                     gridViewColumns = gridViewColumns.toList(),
                                     hideProtocolTagsByDefault = hideProtocolTagsByDefault,
                                     protocolTags = protocolTags.toSet(),
+                                    messageColorScheme = messageColorScheme,
                                 )
                             onSave(newSettings)
                             onDismiss()


### PR DESCRIPTION
- Create MessageColorScheme data class with serialization support
- Add messageColorScheme to AppSettings with default scheme
- Update UI components to use configurable colors instead of hardcoded values
  - FixMessageDisplay.kt: Use scheme for message row colors
  - HierarchicalGridView.kt: Use scheme for grid message colors
  - MessageDetailPanel.kt: Use scheme for direction indicator colors
- Add settings UI section with 3 preset color schemes:
  - Default: Blue/Teal/Red (original colors)
  - Green/Red: Green for outgoing, Blue for incoming
  - Monochrome: Grayscale with red rejections
- Color scheme persisted in settings and applied globally