### PR TITLE
Send FIX Logout message on disconnect and app close

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/main.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/main.kt
@@ -47,8 +47,27 @@ fun main() {
     }
 
     application {
+        // Track if we're closing to avoid duplicate cleanup
+        var isClosing = false
+        var viewModelRef: com.knapsack.fixtool.viewmodel.FixMessageViewModel? = null
+
         Window(
-            onCloseRequest = ::exitApplication,
+            onCloseRequest = {
+                if (!isClosing) {
+                    isClosing = true
+                    logger.info("Window close requested, disconnecting all sessions...")
+
+                    // Disconnect all sessions synchronously before exit
+                    try {
+                        viewModelRef?.disconnectAllSessions()
+                        // Give logout messages time to be sent
+                        Thread.sleep(1000)
+                    } catch (e: Exception) {
+                        logger.error("Error during disconnect on close", e)
+                    }
+                }
+                exitApplication()
+            },
             title = "FixTool - FiX Message Viewer",
             state = WindowState(size = DpSize(1920.dp, 1080.dp)),
             resizable = true,
@@ -79,7 +98,10 @@ fun main() {
                 )
             }
 
-            App(modifier = Modifier.focusRequester(focusRequester).focusable())
+            App(
+                modifier = Modifier.focusRequester(focusRequester).focusable(),
+                onViewModelCreated = { viewModel -> viewModelRef = viewModel },
+            )
         }
     }
 }

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixMessageSession.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixMessageSession.kt
@@ -213,6 +213,15 @@ class FixMessageSession(
 
     fun disconnect() {
         try {
+            // Send logout message if currently logged on
+            if (_connectionState.value == FixConnectionState.LOGGED_ON) {
+                logger.info("Sending logout before disconnect for session: {}", title)
+                quickFixService?.logout()
+
+                // Give the logout message time to be sent before closing socket
+                Thread.sleep(500)
+            }
+
             connectionManager?.stop()
             connectionManager = null
             quickFixService = null

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/service/QuickFixService.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/service/QuickFixService.kt
@@ -179,6 +179,26 @@ class QuickFixService(
         }
     }
 
+    /**
+     * Sends a FIX Logout message to gracefully disconnect from the server
+     * Safe to call even if session is not logged on
+     */
+    fun logout() {
+        val sessionID = currentSessionID
+        if (sessionID == null) {
+            logger.warn("Cannot logout: No active session")
+            return
+        }
+
+        try {
+            logger.info("Sending FIX Logout message for session: {}", sessionID)
+            val session = Session.lookupSession(sessionID)
+            session?.logout()
+        } catch (e: Exception) {
+            logger.error("Error sending logout: {}", e.message, e)
+        }
+    }
+
     companion object {
         private val logger = LoggerFactory.getLogger(QuickFixService::class.java)
     }

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
@@ -38,11 +38,19 @@ private val DarkColorScheme =
 
 @Composable
 @Preview
-fun App(modifier: Modifier = Modifier) {
+fun App(
+    modifier: Modifier = Modifier,
+    onViewModelCreated: (FixMessageViewModel) -> Unit = {},
+) {
     MaterialTheme(
         colorScheme = DarkColorScheme,
     ) {
         val viewModel: FixMessageViewModel = viewModel { FixMessageViewModel() }
+
+        // Expose viewModel reference to parent
+        LaunchedEffect(viewModel) {
+            onViewModelCreated(viewModel)
+        }
         var viewMode by rememberSaveable { mutableStateOf(ViewMode.SPLIT_HORIZONTAL) }
 
         // Collect global state
@@ -64,6 +72,28 @@ fun App(modifier: Modifier = Modifier) {
         LaunchedEffect(viewModel.activeSessionIndex) {
             viewModel.loadSavedMessagesForActiveSession()
         }
+
+        // Add shutdown hook to disconnect all sessions on app close/crash
+        DisposableEffect(Unit) {
+            val shutdownHook =
+                Thread {
+                    viewModel.disconnectAllSessions()
+                }
+            Runtime.getRuntime().addShutdownHook(shutdownHook)
+
+            onDispose {
+                // Clean up sessions when app window closes
+                viewModel.disconnectAllSessions()
+
+                // Remove shutdown hook to avoid duplicate cleanup
+                try {
+                    Runtime.getRuntime().removeShutdownHook(shutdownHook)
+                } catch (e: IllegalStateException) {
+                    // Shutdown in progress, hook already executing
+                }
+            }
+        }
+
         var detailPanelSplitRatio by remember { mutableStateOf(0.2f) }
         var editorPanelSplitRatio by remember {
             mutableStateOf(0.28f)

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
@@ -359,6 +359,21 @@ class FixMessageViewModel : ViewModel() {
         }
     }
 
+    /**
+     * Disconnects all active sessions
+     * Called during app shutdown to gracefully logout from all servers
+     */
+    fun disconnectAllSessions() {
+        logger.info("Disconnecting all sessions (${_sessions.size})")
+        _sessions.forEach { session ->
+            try {
+                session.disconnect()
+            } catch (e: Exception) {
+                logger.error("Error disconnecting session ${session.title}: ${e.message}", e, notifyUser = false)
+            }
+        }
+    }
+
     fun getProfileConnectionState(profileId: String): FixConnectionState {
         val sessionIndex = profileToSessionMap[profileId]
         return if (sessionIndex != null && sessionIndex in _sessions.indices) {


### PR DESCRIPTION
- Add logout() method to QuickFixService using Session.lookupSession().logout()
- Send FIX Logout before closing socket in FixMessageSession.disconnect()
- Add 500ms delay after logout to ensure message is sent
- Add disconnectAllSessions() to FixMessageViewModel for cleanup
- Synchronously disconnect all sessions in main.kt onCloseRequest before exit
- Wait 1000ms for logout messages to complete before app termination
- Add shutdown hook and DisposableEffect as backup cleanup mechanisms

Fixes 'already logged in' error when reconnecting after disconnect/crash by ensuring server receives proper FIX Logout message.