### PR TITLE
Change default view mode from terminal to grid

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/AppSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/AppSettings.kt
@@ -21,6 +21,8 @@ data class AppSettings(
     val protocolTags: Set<Int> = defaultProtocolTags, // List of FIX tags considered as protocol tags
     // Message Color Scheme
     val messageColorScheme: MessageColorScheme = MessageColorScheme.default(),
+    // Default View Mode
+    val defaultViewMode: String = "grid", // Default view mode for new sessions: "grid" or "terminal"
     // Future settings can be added here
     // val theme: String = "dark",
     // val fontSize: Int = 12,

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixMessageSession.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixMessageSession.kt
@@ -18,6 +18,7 @@ class FixMessageSession(
     val id: String = UUID.randomUUID().toString(),
     val title: String,
     private val onError: ((String) -> Unit)? = null,
+    defaultViewMode: String = "grid", // "grid" or "terminal"
 ) {
     companion object {
         private val BUFFER_MSG_SIZE = System.getProperty("noOfMsgToBuffer", "1000").toInt()
@@ -29,7 +30,9 @@ class FixMessageSession(
     private val _messages = MutableStateFlow<List<AppMessage>>(emptyList())
     val messages: StateFlow<List<AppMessage>> = _messages.asStateFlow()
 
-    private val _viewMode = MutableStateFlow(ViewMode.RAW)
+    private val _viewMode = MutableStateFlow(
+        if (defaultViewMode.lowercase() == "grid") ViewMode.PARSED else ViewMode.RAW
+    )
     val viewMode: StateFlow<ViewMode> = _viewMode.asStateFlow()
 
     private val _wrapText = MutableStateFlow(true)

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SettingsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SettingsDialog.kt
@@ -47,6 +47,7 @@ fun SettingsDialog(
     var hideProtocolTagsByDefault by remember { mutableStateOf(currentSettings.hideProtocolTagsByDefault) }
     var protocolTags by remember { mutableStateOf(currentSettings.protocolTags.toMutableSet()) }
     var messageColorScheme by remember { mutableStateOf(currentSettings.messageColorScheme) }
+    var defaultViewMode by remember { mutableStateOf(currentSettings.defaultViewMode) }
 
     Dialog(
         onDismissRequest = onDismiss,
@@ -100,6 +101,7 @@ fun SettingsDialog(
                                 hideProtocolTagsByDefault = defaults.hideProtocolTagsByDefault
                                 protocolTags = defaults.protocolTags.toMutableSet()
                                 messageColorScheme = defaults.messageColorScheme
+                                defaultViewMode = defaults.defaultViewMode
                             },
                             containerColor = restoreDefaultsButtonColor,
                             contentColor = AppTheme.Colors.textSecondary,
@@ -714,6 +716,81 @@ fun SettingsDialog(
                         thickness = AppTheme.Separators.dividerThickness,
                         modifier = Modifier.padding(vertical = AppTheme.Spacing.small),
                     )
+
+                    // Section: Default View Mode
+                    Text(
+                        text = "Default View Mode",
+                        fontSize = 14.sp,
+                        color = AppTheme.Colors.textSecondary,
+                        modifier = Modifier.padding(bottom = 4.dp),
+                    )
+
+                    Text(
+                        text = "Choose the default view mode for new sessions",
+                        fontSize = 11.sp,
+                        color = AppTheme.Colors.textDisabled,
+                        modifier = Modifier.padding(bottom = 8.dp),
+                    )
+
+                    // View mode selection buttons
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        // Grid view button
+                        Box(
+                            modifier = Modifier
+                                .height(32.dp)
+                                .weight(1f)
+                                .background(
+                                    color = if (defaultViewMode == "grid") AppTheme.Colors.primary else AppTheme.Colors.surface,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .border(
+                                    width = 1.dp,
+                                    color = if (defaultViewMode == "grid") AppTheme.Colors.primary else AppTheme.Separators.color,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .clickable { defaultViewMode = "grid" },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Grid View",
+                                fontSize = 11.sp,
+                                color = if (defaultViewMode == "grid") AppTheme.Colors.background else AppTheme.Colors.text
+                            )
+                        }
+
+                        // Terminal view button
+                        Box(
+                            modifier = Modifier
+                                .height(32.dp)
+                                .weight(1f)
+                                .background(
+                                    color = if (defaultViewMode == "terminal") AppTheme.Colors.primary else AppTheme.Colors.surface,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .border(
+                                    width = 1.dp,
+                                    color = if (defaultViewMode == "terminal") AppTheme.Colors.primary else AppTheme.Separators.color,
+                                    shape = RoundedCornerShape(4.dp)
+                                )
+                                .clickable { defaultViewMode = "terminal" },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Terminal View",
+                                fontSize = 11.sp,
+                                color = if (defaultViewMode == "terminal") AppTheme.Colors.background else AppTheme.Colors.text
+                            )
+                        }
+                    }
+
+                    HorizontalDivider(
+                        color = AppTheme.Separators.color,
+                        thickness = AppTheme.Separators.dividerThickness,
+                        modifier = Modifier.padding(vertical = AppTheme.Spacing.small),
+                    )
                 }
 
                 HorizontalDivider(color = AppTheme.Separators.color, thickness = AppTheme.Separators.dividerThickness)
@@ -750,6 +827,7 @@ fun SettingsDialog(
                                     hideProtocolTagsByDefault = hideProtocolTagsByDefault,
                                     protocolTags = protocolTags.toSet(),
                                     messageColorScheme = messageColorScheme,
+                                    defaultViewMode = defaultViewMode,
                                 )
                             onSave(newSettings)
                             onDismiss()

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
@@ -190,6 +190,7 @@ class FixMessageViewModel : ViewModel() {
             FixMessageSession(
                 title = title,
                 onError = { errorMsg -> showNotification(errorMsg, NotificationType.ERROR) },
+                defaultViewMode = appSettings.defaultViewMode,
             )
         _sessions.add(session)
         // Auto-select first session if none is selected

--- a/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/model/SessionDisplayGridModeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/model/SessionDisplayGridModeTest.kt
@@ -23,8 +23,7 @@ class SessionDisplayGridModeTest {
     @Before
     fun setup() {
         session = FixMessageSession(title = "Grid Mode Test Session")
-        // Start in PARSED mode for grid view
-        session.toggleViewMode()
+        // Default is now PARSED mode (grid view) - no need to toggle
         assertEquals(FixMessageSession.ViewMode.PARSED, session.viewMode.value)
     }
 

--- a/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/model/SessionDisplaySplitModeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/model/SessionDisplaySplitModeTest.kt
@@ -568,18 +568,20 @@ class SessionDisplaySplitModeTest {
 
     @Test
     fun testViewModeDefaultsToRaw() {
-        assertEquals(FixMessageSession.ViewMode.RAW, session.viewMode.value)
+        // Default is now PARSED (grid) as per user request
+        assertEquals(FixMessageSession.ViewMode.PARSED, session.viewMode.value)
     }
 
     @Test
     fun testViewModeToggle() {
-        assertEquals(FixMessageSession.ViewMode.RAW, session.viewMode.value)
-
-        session.toggleViewMode()
+        // Default is now PARSED (grid), so first toggle should change to RAW
         assertEquals(FixMessageSession.ViewMode.PARSED, session.viewMode.value)
 
         session.toggleViewMode()
         assertEquals(FixMessageSession.ViewMode.RAW, session.viewMode.value)
+
+        session.toggleViewMode()
+        assertEquals(FixMessageSession.ViewMode.PARSED, session.viewMode.value)
     }
 
     @Test


### PR DESCRIPTION
- Add defaultViewMode setting in AppSettings (default: "grid")
- Update FixMessageSession to initialize with configurable default view
- Add UI controls in Settings dialog to change default view preference
- Update tests to reflect new grid default