### PR TITLE
Fix message routing to wrong session when using duplicate SenderCompI…

### DIFF
--- a/TEST_SUGGESTIONS.md
+++ b/TEST_SUGGESTIONS.md
@@ -1,0 +1,312 @@
+# Suggested Additional Tests for SessionQualifier
+
+**IMPORTANT**: All test data uses generic credentials. Never use production credentials in tests.
+
+## Test Data Guidelines
+
+Use these generic values in all tests:
+- SenderCompID: `SENDER_CLIENT`, `BUYER_FIRM`, `SELLER_FIRM`
+- TargetCompID: `TARGET_SERVER`, `EXCHANGE_TARGET`, `BROKER_TARGET`
+- SessionQualifier: `DEV1`, `LOCAL`, `QA1`, `TEST`, `STAGING`
+- Emails: `test@example.com`, `user@test.com`
+- Hosts: `localhost`, `test.example.com`, `server.test.local`
+
+---
+
+## 🔴 HIGH PRIORITY - Critical Path Tests
+
+### 1. FixConnectionManager Configuration Tests
+
+```kotlin
+// File: FixConnectionManagerTest.kt
+class FixConnectionManagerTest {
+
+    @Test
+    fun testSessionSettingsIncludesSessionQualifier() {
+        val config = FixConnectionConfig(
+            senderCompID = "SENDER_CLIENT",
+            targetCompID = "TARGET_SERVER",
+            sessionQualifier = "DEV1",
+            host = "localhost",
+            port = "9876"
+        )
+
+        // Create manager and verify settings file contains SessionQualifier
+        val settings = createSessionSettings(config)
+        val sessionID = settings.sectionNames().first()
+
+        assertEquals("DEV1", settings.getString(sessionID, "SessionQualifier"))
+    }
+
+    @Test
+    fun testSessionSettingsOmitsEmptySessionQualifier() {
+        val config = FixConnectionConfig(
+            senderCompID = "SENDER_CLIENT",
+            targetCompID = "TARGET_SERVER",
+            sessionQualifier = "",
+            host = "localhost",
+            port = "9876"
+        )
+
+        val settings = createSessionSettings(config)
+        val sessionID = settings.sectionNames().first()
+
+        // Should not have SessionQualifier key when empty
+        assertFalse(settings.isSetting(sessionID, "SessionQualifier"))
+    }
+
+    @Test
+    fun testMultipleManagersWithSameCredentialsButDifferentQualifiers() {
+        val config1 = FixConnectionConfig(
+            senderCompID = "BUYER_FIRM",
+            targetCompID = "EXCHANGE_TARGET",
+            sessionQualifier = "DEV1",
+            port = "9876"
+        )
+
+        val config2 = FixConnectionConfig(
+            senderCompID = "BUYER_FIRM",
+            targetCompID = "EXCHANGE_TARGET",
+            sessionQualifier = "LOCAL",
+            port = "9877"
+        )
+
+        val manager1 = FixConnectionManager(config1, mockService1, appSettings, dictionary)
+        val manager2 = FixConnectionManager(config2, mockService2, appSettings, dictionary)
+
+        // Both should create distinct sessions
+        assertNotEquals(manager1.sessionID, manager2.sessionID)
+    }
+}
+```
+
+### 2. Store File Cleanup Tests
+
+```kotlin
+// Add to: FixConnectionManagerTest.kt
+class StoreFileCleanupTest {
+
+    @Test
+    fun testClearStoreFilesWithQualifier() {
+        val testDir = createTempDir()
+
+        // Create mock store files
+        File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-DEV1.body").createNewFile()
+        File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-DEV1.header").createNewFile()
+        File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-LOCAL.body").createNewFile()
+        File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-LOCAL.header").createNewFile()
+
+        val config = FixConnectionConfig(
+            senderCompID = "BUYER_FIRM",
+            targetCompID = "EXCHANGE_TARGET",
+            sessionQualifier = "DEV1",
+            fileStorePath = testDir.absolutePath,
+            resetOnLogon = true
+        )
+
+        val manager = FixConnectionManager(config, mockService, appSettings, dictionary)
+        manager.start()
+
+        // DEV1 files should be deleted
+        assertFalse(File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-DEV1.body").exists())
+        assertFalse(File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-DEV1.header").exists())
+
+        // LOCAL files should remain
+        assertTrue(File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-LOCAL.body").exists())
+        assertTrue(File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-LOCAL.header").exists())
+    }
+
+    @Test
+    fun testClearStoreFilesWithoutQualifierDoesNotDeleteQualifiedFiles() {
+        val testDir = createTempDir()
+
+        // Create files with and without qualifiers
+        File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET.body").createNewFile()
+        File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-DEV1.body").createNewFile()
+
+        val config = FixConnectionConfig(
+            senderCompID = "BUYER_FIRM",
+            targetCompID = "EXCHANGE_TARGET",
+            sessionQualifier = "",
+            fileStorePath = testDir.absolutePath,
+            resetOnLogon = true
+        )
+
+        val manager = FixConnectionManager(config, mockService, appSettings, dictionary)
+        manager.start()
+
+        // Non-qualified files should be deleted
+        assertFalse(File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET.body").exists())
+
+        // Qualified files should remain
+        assertTrue(File(testDir, "FIX.4.4-BUYER_FIRM-EXCHANGE_TARGET-DEV1.body").exists())
+    }
+}
+```
+
+## 🟡 MEDIUM PRIORITY - Edge Cases & Validation
+
+### 3. SessionQualifier Validation Tests
+
+```kotlin
+// Add to: ConnectionPanelTest.kt or create new ValidationTest.kt
+class SessionQualifierValidationTest {
+
+    @Test
+    fun testSessionQualifierWithSpecialCharacters() {
+        val profile = createTestProfile(
+            sessionQualifier = "ENV-1_TEST.2025"
+        )
+
+        // Should accept alphanumeric, hyphens, underscores, dots
+        assertEquals("ENV-1_TEST.2025", profile.config.sessionQualifier)
+    }
+
+    @Test
+    fun testSessionQualifierMaxLength() {
+        val longQualifier = "A".repeat(255)
+        val profile = createTestProfile(
+            sessionQualifier = longQualifier
+        )
+
+        // Should accept long qualifiers
+        assertEquals(longQualifier, profile.config.sessionQualifier)
+    }
+
+    @Test
+    fun testSessionQualifierCaseSensitivity() {
+        val profile1 = createTestProfile(
+            id = "p1",
+            sessionQualifier = "dev1"
+        )
+        val profile2 = createTestProfile(
+            id = "p2",
+            sessionQualifier = "DEV1"
+        )
+
+        // "dev1" and "DEV1" should be treated as different qualifiers
+        assertNotEquals(profile1.config.sessionQualifier, profile2.config.sessionQualifier)
+    }
+}
+```
+
+### 4. Profile Migration Tests
+
+```kotlin
+// Add to: ConnectionProfileServiceTest.kt
+class ProfileMigrationTest {
+
+    @Test
+    fun testUpgradeMultipleProfilesFromNoQualifierToQualified() {
+        // Simulate upgrade scenario: user has multiple profiles with same credentials
+        val legacyJson = """
+            {
+                "profiles": [
+                    {
+                        "id": "dev1",
+                        "name": "DEV1-BuySide",
+                        "config": {
+                            "senderCompID": "BUYER_FIRM",
+                            "targetCompID": "EXCHANGE_TARGET",
+                            "port": "4440"
+                        }
+                    },
+                    {
+                        "id": "local",
+                        "name": "Local-BuySide",
+                        "config": {
+                            "senderCompID": "BUYER_FIRM",
+                            "targetCompID": "EXCHANGE_TARGET",
+                            "port": "9191"
+                        }
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        testProfilesFile.writeText(legacyJson)
+        val loadedContainer = json.decodeFromString<ProfilesContainer>(testProfilesFile.readText())
+
+        // Both profiles load successfully without sessionQualifier
+        assertEquals(2, loadedContainer.profiles.size)
+        assertEquals("", loadedContainer.profiles[0].config.sessionQualifier)
+        assertEquals("", loadedContainer.profiles[1].config.sessionQualifier)
+
+        // Now add qualifiers and save
+        val upgraded = loadedContainer.profiles.map { profile ->
+            when (profile.id) {
+                "dev1" -> profile.copy(config = profile.config.copy(sessionQualifier = "DEV1"))
+                "local" -> profile.copy(config = profile.config.copy(sessionQualifier = "LOCAL"))
+                else -> profile
+            }
+        }
+
+        val upgradedContainer = ProfilesContainer(upgraded)
+        testProfilesFile.writeText(json.encodeToString(upgradedContainer))
+
+        // Reload and verify upgrade worked
+        val reloadedContainer = json.decodeFromString<ProfilesContainer>(testProfilesFile.readText())
+        assertEquals("DEV1", reloadedContainer.profiles.find { it.id == "dev1" }?.config?.sessionQualifier)
+        assertEquals("LOCAL", reloadedContainer.profiles.find { it.id == "local" }?.config?.sessionQualifier)
+    }
+}
+```
+
+## 🟢 LOW PRIORITY - Integration Tests
+
+### 5. ViewModel Integration Tests
+
+```kotlin
+// Add to: MessageEditorIntegrationTest.kt
+class SessionQualifierViewModelTest {
+
+    @Test
+    fun testViewModelHandlesMultipleSessionsWithSameCredentials() {
+        val viewModel = FixMessageViewModel()
+
+        val dev1Profile = FixConnectionProfile(
+            id = "dev1",
+            name = "DEV1",
+            config = FixConnectionConfig(
+                senderCompID = "BUYER_FIRM",
+                targetCompID = "EXCHANGE_TARGET",
+                sessionQualifier = "DEV1",
+                port = "4440"
+            )
+        )
+
+        val localProfile = FixConnectionProfile(
+            id = "local",
+            name = "LOCAL",
+            config = FixConnectionConfig(
+                senderCompID = "BUYER_FIRM",
+                targetCompID = "EXCHANGE_TARGET",
+                sessionQualifier = "LOCAL",
+                port = "9191"
+            )
+        )
+
+        // Connect both profiles
+        viewModel.connectProfile(dev1Profile.id, dev1Profile)
+        viewModel.connectProfile(localProfile.id, localProfile)
+
+        // Both should create separate sessions
+        assertEquals(2, viewModel.sessions.size)
+
+        // Switch between sessions
+        viewModel.setActiveSession(0) // DEV1
+        assertEquals("DEV1", viewModel.activeSession?.title)
+
+        viewModel.setActiveSession(1) // LOCAL
+        assertEquals("LOCAL", viewModel.activeSession?.title)
+    }
+}
+```
+
+---
+
+## Implementation Priority
+
+1. ✅ **HIGH**: FixConnectionManager tests (#1, #2)
+2. ⚠️ **MEDIUM**: Validation and migration tests (#3, #4)
+3. 📋 **LOW**: Integration tests (#5)

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixConnectionConfig.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixConnectionConfig.kt
@@ -8,6 +8,7 @@ data class FixConnectionConfig(
     val username: String = "",
     val senderCompID: String = "",
     val targetCompID: String = "",
+    val sessionQualifier: String = "", // Optional - differentiates sessions with same SenderCompID/TargetCompID
     val password: String = "",
     val host: String = "localhost",
     val port: String = "",

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/service/FixConnectionManager.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/service/FixConnectionManager.kt
@@ -133,6 +133,13 @@ class FixConnectionManager(
                 appendLine("BeginString=$beginString")
                 appendLine("SenderCompID=${config.senderCompID}")
                 appendLine("TargetCompID=${config.targetCompID}")
+
+                // Add SessionQualifier if specified (to differentiate sessions with same SenderCompID/TargetCompID)
+                if (config.sessionQualifier.isNotBlank()) {
+                    appendLine("SessionQualifier=${config.sessionQualifier}")
+                    logger.info("Using SessionQualifier: {}", config.sessionQualifier)
+                }
+
                 appendLine("HeartBtInt=${config.heartBtInt}")
 
                 if (config.connectionType == FixConnectionConfig.ConnectionType.INITIATOR) {
@@ -226,7 +233,10 @@ class FixConnectionManager(
             val storeDir = File(config.fileStorePath)
             if (storeDir.exists() && storeDir.isDirectory) {
                 storeDir.listFiles()?.forEach { file ->
-                    if (file.name.contains(config.senderCompID) && file.name.contains(config.targetCompID)) {
+                    val matchesSenderTarget = file.name.contains(config.senderCompID) && file.name.contains(config.targetCompID)
+                    val matchesQualifier = config.sessionQualifier.isBlank() || file.name.contains(config.sessionQualifier)
+
+                    if (matchesSenderTarget && matchesQualifier) {
                         val deleted = file.delete()
                         if (deleted) {
                             logger.info("Deleted store file: {}", file.name)

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
@@ -164,9 +164,10 @@ fun App(
                                                 with(density) { (maxWidthPx * editorPanelSplitRatio).toDp() },
                                             ),
                                     ) {
+                                        val activeSession by viewModel.activeSessionState
                                         MessageEditorPanel(
                                             sessions = viewModel.sessions,
-                                            selectedSessionIndex = viewModel.activeSessionIndex,
+                                            selectedSession = activeSession,
                                             dictionary = viewModel.dictionary,
                                             fields = viewModel.editorFields,
                                             selectedFieldIndex = viewModel.editorSelectedFieldIndex,
@@ -190,9 +191,9 @@ fun App(
                                             },
                                             onClearFields = { viewModel.clearEditorFields() },
                                             onClose = { viewModel.toggleMessageEditor() },
-                                            onSend = { sessionIndex, fields ->
+                                            onSend = { fields ->
                                                 val rawMessage = fields.toRawMessage()
-                                                viewModel.sendMessage(sessionIndex, rawMessage)
+                                                viewModel.sendMessage(rawMessage)
                                             },
                                             onValidate = { fields ->
                                                 viewModel.validateEditorMessage(fields)
@@ -228,7 +229,7 @@ fun App(
                                             connectionProfiles = viewModel.connectionProfiles,
                                             currentProfileId = currentProfileId,
                                             currentLoadedMessageName = currentLoadedMessageName,
-                                            onSessionChange = { index -> viewModel.setActiveSession(index) },
+                                            onSessionChange = { session -> viewModel.setActiveSessionByObject(session) },
                                             onError = { errorMsg ->
                                                 viewModel.showNotification(
                                                     errorMsg,
@@ -424,9 +425,10 @@ fun App(
                                                     with(density) { (maxWidthPx * editorPanelSplitRatio).toDp() },
                                                 ),
                                         ) {
+                                            val activeSession by viewModel.activeSessionState
                                             MessageEditorPanel(
                                                 sessions = viewModel.sessions,
-                                                selectedSessionIndex = viewModel.activeSessionIndex,
+                                                selectedSession = activeSession,
                                                 dictionary = viewModel.dictionary,
                                                 fields = viewModel.editorFields,
                                                 selectedFieldIndex = viewModel.editorSelectedFieldIndex,
@@ -450,10 +452,10 @@ fun App(
                                                 },
                                                 onClearFields = { viewModel.clearEditorFields() },
                                                 onClose = { viewModel.toggleMessageEditor() },
-                                                onSend = { sessionIndex, fields ->
+                                                onSend = { fields ->
                                                     val rawMessage =
                                                         fields.joinToString("|") { "${it.tag}=${it.value}" } + "|"
-                                                    viewModel.sendMessage(sessionIndex, rawMessage)
+                                                    viewModel.sendMessage(rawMessage)
                                                 },
                                                 onValidate = { fields ->
                                                     viewModel.validateEditorMessage(fields)
@@ -491,7 +493,7 @@ fun App(
                                                 connectionProfiles = viewModel.connectionProfiles,
                                                 currentProfileId = currentProfileId,
                                                 currentLoadedMessageName = currentLoadedMessageName,
-                                                onSessionChange = { index -> viewModel.setActiveSession(index) },
+                                                onSessionChange = { session -> viewModel.setActiveSessionByObject(session) },
                                                 onError = { errorMsg ->
                                                     viewModel.showNotification(
                                                         errorMsg,

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/ConnectionPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/ConnectionPanel.kt
@@ -47,6 +47,7 @@ fun ConnectionPanel(
     var username by remember { mutableStateOf("") }
     var senderCompID by remember { mutableStateOf("") }
     var targetCompID by remember { mutableStateOf("") }
+    var sessionQualifier by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var host by remember { mutableStateOf("localhost") }
     var port by remember { mutableStateOf("") }
@@ -174,6 +175,7 @@ fun ConnectionPanel(
                     username = profile.config.username
                     senderCompID = profile.config.senderCompID
                     targetCompID = profile.config.targetCompID
+                    sessionQualifier = profile.config.sessionQualifier
                     password = profile.config.password
                     host = profile.config.host
                     port = profile.config.port
@@ -202,6 +204,7 @@ fun ConnectionPanel(
                             username = username,
                             senderCompID = senderCompID,
                             targetCompID = targetCompID,
+                            sessionQualifier = sessionQualifier,
                             password = password,
                             host = host,
                             port = port,
@@ -246,6 +249,7 @@ fun ConnectionPanel(
                         username = ""
                         senderCompID = ""
                         targetCompID = ""
+                        sessionQualifier = ""
                         password = ""
                         host = "localhost"
                         port = ""
@@ -277,6 +281,7 @@ fun ConnectionPanel(
                     username = clonedProfile.config.username
                     senderCompID = clonedProfile.config.senderCompID
                     targetCompID = clonedProfile.config.targetCompID
+                    sessionQualifier = clonedProfile.config.sessionQualifier
                     password = clonedProfile.config.password
                     host = clonedProfile.config.host
                     port = clonedProfile.config.port
@@ -380,6 +385,15 @@ fun ConnectionPanel(
                     modifier = Modifier.weight(1f),
                 )
             }
+
+            // SessionQualifier (optional field to differentiate sessions with same SenderCompID/TargetCompID)
+            ConnectionField(
+                label = "SessionQualifier (optional)",
+                value = sessionQualifier,
+                onValueChange = { sessionQualifier = it },
+                placeholder = "e.g., DEV, LOCAL, QA - use when multiple sessions share same SenderCompID/TargetCompID",
+                modifier = Modifier.fillMaxWidth(),
+            )
 
             // Username and Password on same row
             Row(
@@ -1135,6 +1149,7 @@ fun ConnectionPanel(
                             username = username,
                             senderCompID = senderCompID,
                             targetCompID = targetCompID,
+                            sessionQualifier = sessionQualifier,
                             password = password,
                             host = host,
                             port = port,

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/MessageEditorPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/MessageEditorPanel.kt
@@ -80,7 +80,7 @@ private fun SlimTextField(
 @Composable
 fun MessageEditorPanel(
     sessions: List<FixMessageSession>,
-    selectedSessionIndex: Int,
+    selectedSession: FixMessageSession?,
     dictionary: FixDictionary,
     fields: List<FixField>,
     selectedFieldIndex: Int,
@@ -93,7 +93,7 @@ fun MessageEditorPanel(
     onFieldSelect: (Int, Boolean, Boolean) -> Unit,
     onClearFields: () -> Unit,
     onClose: () -> Unit,
-    onSend: (sessionIndex: Int, fields: List<FixField>) -> Unit,
+    onSend: (fields: List<FixField>) -> Unit,
     onValidate: (fields: List<FixField>) -> List<String>,
     validationErrors: List<String>,
     onClearValidationErrors: () -> Unit,
@@ -106,7 +106,7 @@ fun MessageEditorPanel(
     connectionProfiles: List<com.knapsack.fixtool.model.FixConnectionProfile> = emptyList(),
     currentProfileId: String? = null,
     currentLoadedMessageName: String? = null,
-    onSessionChange: ((Int) -> Unit)? = null,
+    onSessionChange: ((FixMessageSession?) -> Unit)? = null,
     onError: ((String) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -121,7 +121,7 @@ fun MessageEditorPanel(
     // 52=SendingTime, 56=TargetCompID, 57=TargetSubID, 142=SenderLocationID, 143=TargetLocationID
     val managedTags = remember { setOf("8", "9", "10", "34", "49", "50", "52", "56", "57", "142", "143") }
 
-    var currentSessionIndex by remember { mutableStateOf(selectedSessionIndex) }
+    // Use selectedSession directly - no local state needed
     var previewPanelRatio by remember { mutableStateOf(0.2f) }
     var previewText by remember { mutableStateOf("") }
     var isUpdatingFromFields by remember { mutableStateOf(false) }
@@ -132,8 +132,7 @@ fun MessageEditorPanel(
     val density = LocalDensity.current
 
     // Get the current session's connection state
-    val currentSession = sessions.getOrNull(currentSessionIndex)
-    val connectionState by currentSession?.connectionState?.collectAsState() ?: remember {
+    val connectionState by selectedSession?.connectionState?.collectAsState() ?: remember {
         mutableStateOf(
             FixConnectionState.DISCONNECTED,
         )
@@ -238,12 +237,11 @@ fun MessageEditorPanel(
             ) {
                 // Session dropdown - first in toolbar
                 SlimDropdown(
-                    value = if (currentSessionIndex >= 0) sessions.getOrNull(currentSessionIndex) else null,
+                    value = selectedSession,
                     options = sessions,
                     onValueChange = { session ->
-                        val newIndex = if (session != null) sessions.indexOf(session) else -1
-                        currentSessionIndex = newIndex
-                        onSessionChange?.invoke(newIndex)
+                        logger.info("MessageEditorPanel dropdown changed to: ${session?.title} (ID: ${session?.id})")
+                        onSessionChange?.invoke(session)
                     },
                     displayText = { it.title },
                     placeholder = "Session",
@@ -280,8 +278,13 @@ fun MessageEditorPanel(
                                     onSetValidationErrors(
                                         listOf("No fields to send. Add at least one field with tag and value."),
                                     )
+                                } else if (selectedSession == null) {
+                                    onSetValidationErrors(
+                                        listOf("No session selected. Select a session to send message."),
+                                    )
                                 } else {
-                                    onSend(currentSessionIndex, fieldsToSend)
+                                    logger.info("MessageEditorPanel: Calling onSend with selectedSession: ${selectedSession.title} (ID: ${selectedSession.id})")
+                                    onSend(fieldsToSend)
                                 }
                             } catch (e: Exception) {
                                 val sendError = "Send Error: ${e.message ?: e.toString()}"
@@ -856,8 +859,10 @@ fun MessageEditorPanel(
                                                         }
                                                     if (fieldsToSend.isEmpty()) {
                                                         onSetValidationErrors(listOf("No fields to send."))
+                                                    } else if (selectedSession == null) {
+                                                        onSetValidationErrors(listOf("No session selected."))
                                                     } else {
-                                                        onSend(currentSessionIndex, fieldsToSend)
+                                                        onSend(fieldsToSend)
                                                     }
                                                 } catch (e: Exception) {
                                                     onSetValidationErrors(listOf("Send Error: ${e.message}"))

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
@@ -1,5 +1,6 @@
 package com.knapsack.fixtool.viewmodel
 
+import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
@@ -31,9 +32,13 @@ class FixMessageViewModel : ViewModel() {
     private val _activeSessionIndex = mutableStateOf(-1) // -1 means no session selected
     val activeSessionIndex: Int
         get() = _activeSessionIndex.value
+    val activeSessionIndexState: State<Int> = _activeSessionIndex
 
     val activeSession: FixMessageSession?
         get() = if (_activeSessionIndex.value >= 0) _sessions.getOrNull(_activeSessionIndex.value) else null
+
+    private val _activeSessionState = mutableStateOf<FixMessageSession?>(null)
+    val activeSessionState: State<FixMessageSession?> = _activeSessionState
 
     private val _dictionary = mutableStateOf(FixDictionaryAdapter.createDefault())
     val dictionary: FixDictionary
@@ -196,6 +201,7 @@ class FixMessageViewModel : ViewModel() {
         // Auto-select first session if none is selected
         if (_activeSessionIndex.value == -1) {
             _activeSessionIndex.value = 0
+            _activeSessionState.value = session
         }
         return session
     }
@@ -211,13 +217,17 @@ class FixMessageViewModel : ViewModel() {
             // Adjust active index if needed
             if (_sessions.isEmpty()) {
                 _activeSessionIndex.value = -1 // No sessions, so no selection
+                _activeSessionState.value = null
             } else if (_activeSessionIndex.value >= _sessions.size) {
                 _activeSessionIndex.value = _sessions.size - 1
+                _activeSessionState.value = _sessions.getOrNull(_activeSessionIndex.value)
             } else if (_activeSessionIndex.value > index) {
                 _activeSessionIndex.value--
+                _activeSessionState.value = _sessions.getOrNull(_activeSessionIndex.value)
             } else if (_activeSessionIndex.value == index) {
                 // If closing the active session, select the first available session
                 _activeSessionIndex.value = 0
+                _activeSessionState.value = _sessions.getOrNull(0)
             }
 
             // Adjust all session indices in the map that are greater than the closed index
@@ -232,10 +242,31 @@ class FixMessageViewModel : ViewModel() {
 
     fun setActiveSession(index: Int) {
         if (index == -1 || index in _sessions.indices) {
+            val session = if (index >= 0) _sessions.getOrNull(index) else null
+            logger.info("setActiveSession(index=$index): Switching to session: ${session?.title} (ID: ${session?.id})")
             _activeSessionIndex.value = index
+            _activeSessionState.value = session
             // Reload messages when session selection changes
             loadSavedMessagesForActiveSession()
         }
+    }
+
+    fun setActiveSessionByObject(session: FixMessageSession?) {
+        logger.info("setActiveSessionByObject: Switching to session: ${session?.title} (ID: ${session?.id})")
+        if (session == null) {
+            _activeSessionIndex.value = -1
+            _activeSessionState.value = null
+        } else {
+            val index = _sessions.indexOf(session)
+            if (index >= 0) {
+                logger.info("setActiveSessionByObject: Found session at index $index")
+                _activeSessionIndex.value = index
+                _activeSessionState.value = session
+            } else {
+                logger.warn("setActiveSessionByObject: Session not found in sessions list!")
+            }
+        }
+        loadSavedMessagesForActiveSession()
     }
 
     fun selectMessage(message: FixMessage?) {
@@ -318,9 +349,21 @@ class FixMessageViewModel : ViewModel() {
         validateDataDictionary()
     }
 
-    fun sendMessage(sessionIndex: Int, rawMessage: String) {
-        // Use sendFixMessage which handles both demo and real connections
-        _sessions.getOrNull(sessionIndex)?.sendFixMessage(rawMessage, _dictionary.value)
+    fun sendMessage(rawMessage: String) {
+        // Use the currently active session to send message
+        logger.info("sendMessage called. Active session index: ${_activeSessionIndex.value}")
+        logger.info("sendMessage: _activeSessionState.value = ${_activeSessionState.value?.title} (ID: ${_activeSessionState.value?.id})")
+        logger.info("sendMessage: activeSession computed = ${activeSession?.title} (ID: ${activeSession?.id})")
+
+        // Use _activeSessionState directly instead of computed activeSession
+        val session = _activeSessionState.value
+        if (session == null) {
+            logger.error("sendMessage: No active session found! activeSessionIndex=${_activeSessionIndex.value}, sessions.size=${_sessions.size}", notifyUser = true)
+        } else {
+            logger.info("sendMessage: Sending to session: '${session.title}' (ID: ${session.id})")
+            session.sendFixMessage(rawMessage, _dictionary.value)
+            logger.info("sendMessage: Message sent successfully to ${session.title}")
+        }
     }
 
     // Connection management methods
@@ -861,6 +904,18 @@ class FixMessageViewModel : ViewModel() {
      */
     fun clearAllNotifications() {
         _notifications.clear()
+    }
+
+    // ========================================
+    // Test Helper Methods
+    // ========================================
+
+    /**
+     * Creates a new session for testing purposes.
+     * This is a public wrapper around createNewSession for use in tests.
+     */
+    fun createSessionForTest(title: String = "Test Session"): FixMessageSession {
+        return createNewSession(title)
     }
 
     override fun onCleared() {

--- a/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/service/ConnectionProfileServiceTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/service/ConnectionProfileServiceTest.kt
@@ -1,0 +1,245 @@
+package com.knapsack.fixtool.service
+
+import com.knapsack.fixtool.model.FixConnectionConfig
+import com.knapsack.fixtool.model.FixConnectionProfile
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ConnectionProfileServiceTest {
+    private lateinit var testProfilesFile: File
+    private lateinit var testDir: File
+    private lateinit var json: Json
+
+    @Before
+    fun setup() {
+        // Create a temporary test directory
+        testDir = File.createTempFile("test_fixtool", "")
+        testDir.delete()
+        testDir.mkdirs()
+        testDir.deleteOnExit()
+
+        testProfilesFile = File(testDir, "connection_profiles.json")
+
+        json = Json {
+            prettyPrint = true
+            ignoreUnknownKeys = true
+        }
+    }
+
+    @After
+    fun cleanup() {
+        testProfilesFile.delete()
+        testDir.deleteRecursively()
+    }
+
+    @Test
+    fun testSerializeProfileWithEmptySessionQualifier() {
+        val profile = createTestProfile(
+            id = "test-1",
+            name = "Test Profile",
+            sessionQualifier = ""
+        )
+
+        val container = ProfilesContainer(listOf(profile))
+        val jsonString = json.encodeToString(container)
+        testProfilesFile.writeText(jsonString)
+
+        val loadedString = testProfilesFile.readText()
+        val loadedContainer = json.decodeFromString<ProfilesContainer>(loadedString)
+
+        assertEquals(1, loadedContainer.profiles.size)
+        assertEquals("Test Profile", loadedContainer.profiles[0].name)
+        assertEquals("", loadedContainer.profiles[0].config.sessionQualifier)
+    }
+
+    @Test
+    fun testSerializeProfileWithSessionQualifier() {
+        val profile = createTestProfile(
+            id = "dev1",
+            name = "DEV1-BuySide",
+            sessionQualifier = "DEV1"
+        )
+
+        val container = ProfilesContainer(listOf(profile))
+        val jsonString = json.encodeToString(container)
+        testProfilesFile.writeText(jsonString)
+
+        val loadedString = testProfilesFile.readText()
+        val loadedContainer = json.decodeFromString<ProfilesContainer>(loadedString)
+
+        assertEquals(1, loadedContainer.profiles.size)
+        assertEquals("DEV1-BuySide", loadedContainer.profiles[0].name)
+        assertEquals("DEV1", loadedContainer.profiles[0].config.sessionQualifier)
+    }
+
+    @Test
+    fun testSerializeMultipleProfilesWithDifferentQualifiers() {
+        val dev1Profile = createTestProfile(
+            id = "dev1",
+            name = "DEV1-BuySide",
+            senderCompID = "SENDER_CLIENT",
+            targetCompID = "TARGET_SERVER",
+            sessionQualifier = "DEV1"
+        )
+
+        val localProfile = createTestProfile(
+            id = "local",
+            name = "Local-BuySide",
+            senderCompID = "SENDER_CLIENT",
+            targetCompID = "TARGET_SERVER",
+            sessionQualifier = "LOCAL"
+        )
+
+        val qa1Profile = createTestProfile(
+            id = "qa1",
+            name = "QA1-BuySide",
+            senderCompID = "SENDER_CLIENT",
+            targetCompID = "TARGET_SERVER",
+            sessionQualifier = "QA1"
+        )
+
+        val container = ProfilesContainer(listOf(dev1Profile, localProfile, qa1Profile))
+        val jsonString = json.encodeToString(container)
+        testProfilesFile.writeText(jsonString)
+
+        val loadedString = testProfilesFile.readText()
+        val loadedContainer = json.decodeFromString<ProfilesContainer>(loadedString)
+
+        assertEquals(3, loadedContainer.profiles.size)
+
+        val dev1Loaded = loadedContainer.profiles.find { it.id == "dev1" }
+        assertNotNull(dev1Loaded)
+        assertEquals("DEV1", dev1Loaded.config.sessionQualifier)
+
+        val localLoaded = loadedContainer.profiles.find { it.id == "local" }
+        assertNotNull(localLoaded)
+        assertEquals("LOCAL", localLoaded.config.sessionQualifier)
+
+        val qa1Loaded = loadedContainer.profiles.find { it.id == "qa1" }
+        assertNotNull(qa1Loaded)
+        assertEquals("QA1", qa1Loaded.config.sessionQualifier)
+    }
+
+    @Test
+    fun testDeserializeLegacyProfileWithoutSessionQualifier() {
+        // Simulate an old profile JSON without sessionQualifier field
+        val legacyJson = """
+            {
+                "profiles": [
+                    {
+                        "id": "legacy-1",
+                        "name": "Legacy Profile",
+                        "config": {
+                            "username": "testuser",
+                            "senderCompID": "SENDER",
+                            "targetCompID": "TARGET",
+                            "password": "testpass",
+                            "host": "localhost",
+                            "port": "9876",
+                            "beginString": "FIX.4.4",
+                            "heartBtInt": "30",
+                            "resetOnLogon": false,
+                            "resetOnLogout": false,
+                            "resetOnDisconnect": false,
+                            "showHeartbeat": true,
+                            "customParameters": {},
+                            "logonFields": {}
+                        },
+                        "createdAt": 1234567890,
+                        "lastUsedAt": 1234567890
+                    }
+                ]
+            }
+        """.trimIndent()
+
+        testProfilesFile.writeText(legacyJson)
+
+        val loadedContainer = json.decodeFromString<ProfilesContainer>(testProfilesFile.readText())
+
+        assertEquals(1, loadedContainer.profiles.size)
+        assertEquals("Legacy Profile", loadedContainer.profiles[0].name)
+        // Should default to empty string when not present
+        assertEquals("", loadedContainer.profiles[0].config.sessionQualifier)
+    }
+
+    @Test
+    fun testProfilesWithSameSenderTargetButDifferentQualifiers() {
+        val senderCompID = "common.sender@example.com"
+        val targetCompID = "COMMON_TARGET"
+
+        val profile1 = createTestProfile(
+            id = "env1",
+            name = "Environment 1",
+            senderCompID = senderCompID,
+            targetCompID = targetCompID,
+            sessionQualifier = "ENV1"
+        )
+
+        val profile2 = createTestProfile(
+            id = "env2",
+            name = "Environment 2",
+            senderCompID = senderCompID,
+            targetCompID = targetCompID,
+            sessionQualifier = "ENV2"
+        )
+
+        val container = ProfilesContainer(listOf(profile1, profile2))
+        val jsonString = json.encodeToString(container)
+        testProfilesFile.writeText(jsonString)
+
+        val loadedContainer = json.decodeFromString<ProfilesContainer>(testProfilesFile.readText())
+
+        assertEquals(2, loadedContainer.profiles.size)
+
+        // Both profiles have same sender/target but different qualifiers
+        loadedContainer.profiles.forEach { profile ->
+            assertEquals(senderCompID, profile.config.senderCompID)
+            assertEquals(targetCompID, profile.config.targetCompID)
+        }
+
+        val env1 = loadedContainer.profiles.find { it.id == "env1" }
+        assertNotNull(env1)
+        assertEquals("ENV1", env1.config.sessionQualifier)
+
+        val env2 = loadedContainer.profiles.find { it.id == "env2" }
+        assertNotNull(env2)
+        assertEquals("ENV2", env2.config.sessionQualifier)
+    }
+
+    private fun createTestProfile(
+        id: String,
+        name: String,
+        senderCompID: String = "SENDER",
+        targetCompID: String = "TARGET",
+        sessionQualifier: String = ""
+    ): FixConnectionProfile {
+        return FixConnectionProfile(
+            id = id,
+            name = name,
+            config = FixConnectionConfig(
+                senderCompID = senderCompID,
+                targetCompID = targetCompID,
+                sessionQualifier = sessionQualifier,
+                username = "testuser",
+                password = "testpass",
+                host = "localhost",
+                port = "9876",
+                beginString = "FIX.4.4",
+                heartBtInt = "30"
+            )
+        )
+    }
+
+    @Serializable
+    private data class ProfilesContainer(
+        val profiles: List<FixConnectionProfile>,
+    )
+}

--- a/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/ui/ConnectionPanelTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/ui/ConnectionPanelTest.kt
@@ -20,6 +20,7 @@ class ConnectionPanelTest {
         name: String = "Test Profile",
         senderCompID: String = "SENDER",
         targetCompID: String = "TARGET",
+        sessionQualifier: String = "",
     ): FixConnectionProfile =
         FixConnectionProfile(
             id = id,
@@ -28,6 +29,7 @@ class ConnectionPanelTest {
                 FixConnectionConfig(
                     senderCompID = senderCompID,
                     targetCompID = targetCompID,
+                    sessionQualifier = sessionQualifier,
                     username = "testuser",
                     password = "testpass",
                     host = "localhost",
@@ -845,5 +847,118 @@ class ConnectionPanelTest {
 
         // Delete button should now be visible
         composeTestRule.onNodeWithContentDescription("Delete Profile").assertExists()
+    }
+
+    @Test
+    fun testSessionQualifierFieldExists() {
+        composeTestRule.setContent {
+            ConnectionPanel(
+                profiles = emptyList(),
+                sessions = emptyList(),
+                onConnect = { _, _ -> },
+                onDisconnect = { },
+                onSaveProfile = { },
+                onDeleteProfile = { },
+                onCloneProfile = { it },
+                onGetProfileSession = { null },
+                onClose = { },
+            )
+        }
+
+        // SessionQualifier field should be visible
+        composeTestRule.onNodeWithText("SessionQualifier (optional)").assertExists()
+    }
+
+    @Test
+    fun testLoadProfileWithSessionQualifier() {
+        val profileWithQualifier = createTestProfile(
+            id = "dev1",
+            name = "DEV1 Profile",
+            senderCompID = "SENDER_CLIENT",
+            targetCompID = "TARGET_SERVER",
+            sessionQualifier = "DEV1"
+        )
+        val profiles = listOf(profileWithQualifier)
+
+        var savedProfile: FixConnectionProfile? = null
+
+        composeTestRule.setContent {
+            ConnectionPanel(
+                profiles = profiles,
+                sessions = emptyList(),
+                onConnect = { _, _ -> },
+                onDisconnect = { },
+                onSaveProfile = { savedProfile = it },
+                onDeleteProfile = { },
+                onCloneProfile = { it },
+                onGetProfileSession = { null },
+                onClose = { },
+            )
+        }
+
+        // Select the profile with session qualifier
+        composeTestRule.onNodeWithText("Select profile...").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("DEV1 Profile").performClick()
+        composeTestRule.waitForIdle()
+
+        // Verify SessionQualifier field shows the value
+        composeTestRule.onNodeWithText("DEV1").assertExists()
+
+        // Save the profile (should preserve session qualifier)
+        composeTestRule.onNodeWithContentDescription("Save Profile").performClick()
+        composeTestRule.waitForIdle()
+
+        // Verify saved profile has the session qualifier
+        assertNotNull(savedProfile)
+        assertEquals("DEV1", savedProfile?.config?.sessionQualifier)
+    }
+
+    @Test
+    fun testCloneProfilePreservesSessionQualifier() {
+        var clonedProfile: FixConnectionProfile? = null
+        val originalProfile = createTestProfile(
+            id = "original-qual",
+            name = "Original Qualified",
+            senderCompID = "SENDER_QUAL",
+            targetCompID = "TARGET_QUAL",
+            sessionQualifier = "ORIGINAL_QUAL"
+        )
+        val profiles = listOf(originalProfile)
+
+        composeTestRule.setContent {
+            ConnectionPanel(
+                profiles = profiles,
+                sessions = emptyList(),
+                onConnect = { _, _ -> },
+                onDisconnect = { },
+                onSaveProfile = { },
+                onDeleteProfile = { },
+                onCloneProfile = { profile ->
+                    val cloned = profile.copy(
+                        id = "cloned-${profile.id}",
+                        name = "${profile.name} (Copy)"
+                    )
+                    clonedProfile = cloned
+                    cloned
+                },
+                onGetProfileSession = { null },
+                onClose = { },
+            )
+        }
+
+        // Select the profile
+        composeTestRule.onNodeWithText("Select profile...").performClick()
+        composeTestRule.waitForIdle()
+        composeTestRule.onNodeWithText("Original Qualified").performClick()
+        composeTestRule.waitForIdle()
+
+        // Clone the profile
+        composeTestRule.onNodeWithContentDescription("Clone Profile").performClick()
+        composeTestRule.waitForIdle()
+
+        // Verify cloned profile preserves session qualifier
+        assertNotNull(clonedProfile)
+        assertEquals("ORIGINAL_QUAL", clonedProfile?.config?.sessionQualifier)
     }
 }

--- a/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/viewmodel/MessageEditorIntegrationTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/viewmodel/MessageEditorIntegrationTest.kt
@@ -402,4 +402,99 @@ class MessageEditorIntegrationTest {
         assertTrue(rawMessage.contains("58=Test message with spaces"))
         assertTrue(rawMessage.contains("100=VALUE=WITH|PIPES"))
     }
+
+    // ========================================
+    // Session Selection Tests
+    // ========================================
+
+    @Test
+    fun testSendMessageToCorrectSessionAfterSessionSwitch() {
+        // Create two sessions
+        val session1 = viewModel.createSessionForTest("Session 1")
+        val session2 = viewModel.createSessionForTest("Session 2")
+
+        // Initially on session 0 (first session)
+        assertEquals(0, viewModel.activeSessionIndex)
+
+        // Build a message
+        viewModel.updateEditorField(0, FixField(tag = "35", value = "D"))
+        viewModel.addEditorField()
+        viewModel.updateEditorField(1, FixField(tag = "11", value = "ORDER_SESSION_1"))
+
+        // Session 1 should be active by default (first session created)
+        assertEquals(0, viewModel.activeSessionIndex)
+        assertEquals(session1, viewModel.activeSession)
+
+        // Build and send message to active session (session1)
+        val testMessage = viewModel.editorFields.toRawMessage()
+        viewModel.sendMessage(testMessage)
+
+        // Verify message contains expected data
+        assertTrue(testMessage.contains("ORDER_SESSION_1"))
+
+        // Switch to session 2 (second session, index 1)
+        viewModel.setActiveSession(1)
+        assertEquals(1, viewModel.activeSessionIndex)
+        assertEquals(session2, viewModel.activeSession)
+
+        // Update the message
+        viewModel.updateEditorField(1, FixField(tag = "11", value = "ORDER_SESSION_2"))
+
+        // Send message - should go to active session (session2)
+        val testMessage2 = viewModel.editorFields.toRawMessage()
+        viewModel.sendMessage(testMessage2)
+
+        // Verify message sent contains expected data
+        assertTrue(testMessage2.contains("ORDER_SESSION_2"))
+    }
+
+    @Test
+    fun testActiveSessionIndexTracksCorrectly() {
+        // Create three sessions
+        viewModel.createSessionForTest("Session 1")
+        viewModel.createSessionForTest("Session 2")
+        viewModel.createSessionForTest("Session 3")
+
+        // Verify initial session is 0
+        assertEquals(0, viewModel.activeSessionIndex)
+
+        // Switch to session 1
+        viewModel.setActiveSession(1)
+        assertEquals(1, viewModel.activeSessionIndex)
+
+        // Switch to session 2
+        viewModel.setActiveSession(2)
+        assertEquals(2, viewModel.activeSessionIndex)
+
+        // Switch back to session 0
+        viewModel.setActiveSession(0)
+        assertEquals(0, viewModel.activeSessionIndex)
+    }
+
+    @Test
+    fun testSessionSwitchBeforeSendingMessage() {
+        // Create two sessions
+        viewModel.createSessionForTest("Session A")
+        viewModel.createSessionForTest("Session B")
+
+        // Build a message while on session 0
+        viewModel.updateEditorField(0, FixField(tag = "35", value = "D"))
+        viewModel.addEditorField()
+        viewModel.updateEditorField(1, FixField(tag = "11", value = "ORDER_A"))
+
+        val message = viewModel.editorFields.toRawMessage()
+
+        // Switch to session 1 (Session B) before sending
+        viewModel.setActiveSession(1)
+        val session2 = viewModel.sessions[1]
+        assertEquals(session2, viewModel.activeSession)
+
+        // Send message - should go to active session (Session B)
+        viewModel.sendMessage(message)
+
+        // Verify we're still on session 1 and message contains expected value
+        assertEquals(1, viewModel.activeSessionIndex)
+        assertEquals(session2, viewModel.activeSession)
+        assertTrue(message.contains("ORDER_A"))
+    }
 }


### PR DESCRIPTION
…D/TargetCompID

Root cause: QuickFIX identifies sessions using BeginString, SenderCompID, TargetCompID, and SessionQualifier. Multiple connection profiles (DEV1-BuySide, Local-BuySide, QA1-BuySide) shared identical FIX credentials with no SessionQualifier, causing QuickFIX to treat them as the same session. Messages sent to Local-BuySide were incorrectly routed through DEV1-BuySide's connection.

Changes:
- Add sessionQualifier field to FixConnectionConfig model
- Update FixConnectionManager to include SessionQualifier in QuickFIX settings
- Add SessionQualifier input field to ConnectionPanel UI
- Update connection profile persistence to handle sessionQualifier
- Migrate existing profiles with appropriate qualifiers:
  * DEV1 profiles: sessionQualifier = "DEV1"
  * LOCAL profiles: sessionQualifier = "LOCAL"
  * QA1 profiles: sessionQualifier = "QA1"

This ensures each session has a unique QuickFIX SessionID, preventing message routing conflicts between environments sharing the same FIX credentials.