### PR TITLE
refactor: Convert protocol tags visibility to global app setting

### DIFF
--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/AppSettings.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/AppSettings.kt
@@ -17,7 +17,7 @@ data class AppSettings(
     // Grid View Settings
     val gridViewColumns: List<Int> = listOf(11, 131, 693), // List of FIX tags to display as columns (ClOrdID, QuoteReqID, QuoteRequestRejectReason)
     // Protocol Tags Settings
-    val hideProtocolTagsByDefault: Boolean = true, // Hide protocol tags by default in message details
+    val hideProtocolTags: Boolean = true, // Hide protocol tags in message details (global setting)
     val protocolTags: Set<Int> = defaultProtocolTags, // List of FIX tags considered as protocol tags
     // Message Color Scheme
     val messageColorScheme: MessageColorScheme = MessageColorScheme.default(),

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixMessageSession.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/model/FixMessageSession.kt
@@ -63,10 +63,6 @@ class FixMessageSession(
     private val _filterMessageTypes = MutableStateFlow("")
     val filterMessageTypes: StateFlow<String> = _filterMessageTypes.asStateFlow()
 
-    // Hide protocol tags state (for PARSED view)
-    private val _hideProtocolTags = MutableStateFlow(true)
-    val hideProtocolTags: StateFlow<Boolean> = _hideProtocolTags.asStateFlow()
-
     // Recently sent message timestamp (for highlighting)
     private val _recentlySentMessageTimestamp = MutableStateFlow<LocalDateTime?>(null)
     val recentlySentMessageTimestamp: StateFlow<LocalDateTime?> = _recentlySentMessageTimestamp.asStateFlow()
@@ -133,10 +129,6 @@ class FixMessageSession(
 
     fun setFilterMessageTypes(types: String) {
         _filterMessageTypes.value = types
-    }
-
-    fun toggleHideProtocolTags() {
-        _hideProtocolTags.value = !_hideProtocolTags.value
     }
 
     private fun startMessagePolling() {

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/App.kt
@@ -147,6 +147,7 @@ fun App(
                     globalFilterRegex = globalFilterRegex,
                     globalFilterShowIncoming = globalFilterShowIncoming,
                     globalFilterShowOutgoing = globalFilterShowOutgoing,
+                    hideProtocolTags = viewModel.appSettings.hideProtocolTags,
                     onOpenMessageEditor = { viewModel.toggleMessageEditor() },
                     onToggleDetailPanel = { viewModel.toggleDetailPanel() },
                     onToggleConnectionPanel = { viewModel.toggleConnectionPanel() },
@@ -170,6 +171,7 @@ fun App(
                     onGlobalFilterChange = { regex -> viewModel.setGlobalFilterRegex(regex) },
                     onGlobalFilterIncomingChange = { show -> viewModel.setGlobalFilterShowIncoming(show) },
                     onGlobalFilterOutgoingChange = { show -> viewModel.setGlobalFilterShowOutgoing(show) },
+                    onToggleHideProtocolTags = { viewModel.toggleHideProtocolTags() },
                     onOpenSettings = { viewModel.toggleSettingsDialog() },
                 )
 
@@ -330,7 +332,6 @@ fun App(
                                         val messages by session.messages.collectAsState()
                                         val sessionViewMode by session.viewMode.collectAsState()
                                         val wrapText by session.wrapText.collectAsState()
-                                        val hideProtocolTags by session.hideProtocolTags.collectAsState()
                                         val recentlySentMessageTimestamp by session.recentlySentMessageTimestamp.collectAsState()
 
                                         FixMessageDisplay(
@@ -342,7 +343,7 @@ fun App(
                                             recentlySentMessageTimestamp = recentlySentMessageTimestamp,
                                             onSelectMessage = { message -> viewModel.selectMessage(message) },
                                             showDetailPanel = false,
-                                            hideProtocolTags = hideProtocolTags,
+                                            hideProtocolTags = viewModel.appSettings.hideProtocolTags,
                                             gridViewColumns = viewModel.appSettings.gridViewColumns,
                                             appSettings = viewModel.appSettings,
                                             modifier = Modifier.weight(1f),

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/MessageDetailPanel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/MessageDetailPanel.kt
@@ -52,7 +52,6 @@ fun MessageDetailPanel(
     val listState = rememberLazyListState()
     val density = LocalDensity.current
     var rawMessageSplitRatio by remember { mutableStateOf(0.2f) } // Raw message section takes 30% by default
-    var hideProtocolTags by remember { mutableStateOf(appSettings.hideProtocolTagsByDefault) } // Use setting
     var searchQuery by remember { mutableStateOf("") }
 
     Box(
@@ -107,25 +106,9 @@ fun MessageDetailPanel(
                                 modifier = iconSize,
                             )
                         }
-
-                        Spacer(modifier = Modifier.width(4.dp))
-
-                        // Toggle protocol tags button
-                        TooltipIconButton(
-                            tooltip = if (hideProtocolTags) "Show Protocol Tags" else "Hide Protocol Tags",
-                            onClick = { hideProtocolTags = !hideProtocolTags },
-                            modifier = buttonSize,
-                        ) {
-                            Icon(
-                                imageVector = if (hideProtocolTags) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                                contentDescription = if (hideProtocolTags) "Show Protocol Tags" else "Hide Protocol Tags",
-                                tint = iconTintColor,
-                                modifier = iconSize,
-                            )
-                        }
-
-                        Spacer(modifier = Modifier.width(4.dp))
                     }
+
+                    Spacer(modifier = Modifier.width(4.dp))
 
                     // Close button
                     TooltipIconButton(
@@ -250,7 +233,7 @@ fun MessageDetailPanel(
                                         renderQuickFixMessage(
                                             message = message.quickfixMessage,
                                             dictionary = dictionary,
-                                            hideProtocolTags = hideProtocolTags,
+                                            hideProtocolTags = appSettings.hideProtocolTags,
                                             searchQuery = searchQuery,
                                             protocolTags = appSettings.protocolTags,
                                             expandedGroups = expandedGroups,

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SettingsDialog.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SettingsDialog.kt
@@ -44,7 +44,7 @@ fun SettingsDialog(
     var validateUserDefinedFields by remember { mutableStateOf(currentSettings.validateUserDefinedFields) }
     var validateIncomingMessage by remember { mutableStateOf(currentSettings.validateIncomingMessage) }
     var gridViewColumns by remember { mutableStateOf(currentSettings.gridViewColumns.toMutableList()) }
-    var hideProtocolTagsByDefault by remember { mutableStateOf(currentSettings.hideProtocolTagsByDefault) }
+    var hideProtocolTags by remember { mutableStateOf(currentSettings.hideProtocolTags) }
     var protocolTags by remember { mutableStateOf(currentSettings.protocolTags.toMutableSet()) }
     var messageColorScheme by remember { mutableStateOf(currentSettings.messageColorScheme) }
     var defaultViewMode by remember { mutableStateOf(currentSettings.defaultViewMode) }
@@ -100,7 +100,7 @@ fun SettingsDialog(
                                 validateUserDefinedFields = defaults.validateUserDefinedFields
                                 validateIncomingMessage = defaults.validateIncomingMessage
                                 gridViewColumns = defaults.gridViewColumns.toMutableList()
-                                hideProtocolTagsByDefault = defaults.hideProtocolTagsByDefault
+                                hideProtocolTags = defaults.hideProtocolTags
                                 protocolTags = defaults.protocolTags.toMutableSet()
                                 messageColorScheme = defaults.messageColorScheme
                                 defaultViewMode = defaults.defaultViewMode
@@ -610,8 +610,8 @@ fun SettingsDialog(
                     CheckboxSetting(
                         label = "Hide Protocol Tags by Default",
                         description = "Automatically hide protocol tags when viewing message details",
-                        checked = hideProtocolTagsByDefault,
-                        onCheckedChange = { hideProtocolTagsByDefault = it },
+                        checked = hideProtocolTags,
+                        onCheckedChange = { hideProtocolTags = it },
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))
@@ -1028,7 +1028,7 @@ fun SettingsDialog(
                                     validateUserDefinedFields = validateUserDefinedFields,
                                     validateIncomingMessage = validateIncomingMessage,
                                     gridViewColumns = gridViewColumns.toList(),
-                                    hideProtocolTagsByDefault = hideProtocolTagsByDefault,
+                                    hideProtocolTags = hideProtocolTags,
                                     protocolTags = protocolTags.toSet(),
                                     messageColorScheme = messageColorScheme,
                                     defaultViewMode = defaultViewMode,

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SplitView.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/SplitView.kt
@@ -273,7 +273,6 @@ private fun SessionPanel(
     val filterShowSeparator by session.filterShowSeparator.collectAsState()
     val filterMessageTypes by session.filterMessageTypes.collectAsState()
     val connectionState by session.connectionState.collectAsState()
-    val hideProtocolTags by session.hideProtocolTags.collectAsState()
     val recentlySentMessageTimestamp by session.recentlySentMessageTimestamp.collectAsState()
 
     Column(
@@ -411,24 +410,6 @@ private fun SessionPanel(
                     tint = AppTheme.Colors.textSecondary,
                     modifier = Modifier.size(16.dp),
                 )
-            }
-
-            // Protocol tags toggle (only visible in PARSED mode)
-            if (sessionViewMode == FixMessageSession.ViewMode.PARSED) {
-                Spacer(modifier = Modifier.width(2.dp))
-
-                TooltipIconButton(
-                    tooltip = if (hideProtocolTags) "Show Protocol Tags" else "Hide Protocol Tags",
-                    onClick = { session.toggleHideProtocolTags() },
-                    modifier = Modifier.size(buttonSize),
-                ) {
-                    Icon(
-                        imageVector = if (hideProtocolTags) Icons.Default.VisibilityOff else Icons.Default.Visibility,
-                        contentDescription = if (hideProtocolTags) "Show Protocol Tags" else "Hide Protocol Tags",
-                        tint = iconTintColor,
-                        modifier = Modifier.size(iconSize),
-                    )
-                }
             }
 
             // View mode toggle for this session - shows destination icon (matching global toolbar)
@@ -832,7 +813,7 @@ private fun SessionPanel(
             onPasteMessage = onPasteMessage,
             showDetailPanel = false,
             searchVisible = searchVisible,
-            hideProtocolTags = hideProtocolTags,
+            hideProtocolTags = appSettings.hideProtocolTags,
             gridViewColumns = gridViewColumns,
             appSettings = appSettings,
             onToggleSearch = { session.toggleSearch() },

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/TabBar.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/TabBar.kt
@@ -67,7 +67,6 @@ fun TabBar(
                 val connectionState by activeSession.connectionState.collectAsState()
                 val searchVisible by activeSession.searchVisible.collectAsState()
                 val filterVisible by activeSession.filterVisible.collectAsState()
-                val hideProtocolTags by activeSession.hideProtocolTags.collectAsState()
 
                 // RAW mode specific buttons (wrap, search)
                 if (viewMode == FixMessageSession.ViewMode.RAW) {

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/Toolbar.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/ui/Toolbar.kt
@@ -44,6 +44,7 @@ fun Toolbar(
     globalFilterRegex: String = "",
     globalFilterShowIncoming: Boolean = true,
     globalFilterShowOutgoing: Boolean = true,
+    hideProtocolTags: Boolean = true,
     onOpenMessageEditor: (() -> Unit)? = null,
     onToggleDetailPanel: (() -> Unit)? = null,
     onToggleConnectionPanel: (() -> Unit)? = null,
@@ -57,6 +58,7 @@ fun Toolbar(
     onGlobalFilterChange: ((String) -> Unit)? = null,
     onGlobalFilterIncomingChange: ((Boolean) -> Unit)? = null,
     onGlobalFilterOutgoingChange: ((Boolean) -> Unit)? = null,
+    onToggleHideProtocolTags: (() -> Unit)? = null,
     onOpenSettings: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -398,6 +400,22 @@ fun Toolbar(
                         },
                     contentDescription = "Toggle View for All Sessions",
                     tint = toggleDisabledColor(activeSessionViewMode != null, AppTheme.Colors.textSecondary, AppTheme.Colors.textDisabled),
+                    modifier = tooltipIconModifier,
+                )
+            }
+        }
+
+        // Hide/Show Protocol Tags Toggle (applies to all sessions)
+        if (onToggleHideProtocolTags != null) {
+            TooltipIconButton(
+                tooltip = if (hideProtocolTags) "Show Protocol Tags" else "Hide Protocol Tags",
+                onClick = onToggleHideProtocolTags,
+                modifier = tooltipModifier,
+            ) {
+                Icon(
+                    imageVector = if (hideProtocolTags) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                    contentDescription = if (hideProtocolTags) "Show Protocol Tags" else "Hide Protocol Tags",
+                    tint = AppTheme.Colors.textSecondary,
                     modifier = tooltipIconModifier,
                 )
             }

--- a/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/com/knapsack/fixtool/viewmodel/FixMessageViewModel.kt
@@ -371,6 +371,11 @@ class FixMessageViewModel : ViewModel() {
         _showConnectionPanel.value = !_showConnectionPanel.value
     }
 
+    fun toggleHideProtocolTags() {
+        val updatedSettings = appSettings.copy(hideProtocolTags = !appSettings.hideProtocolTags)
+        saveAppSettings(updatedSettings)
+    }
+
     fun toggleSettingsDialog() {
         _showSettingsDialog.value = !_showSettingsDialog.value
     }

--- a/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/model/SessionDisplayGridModeTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/model/SessionDisplayGridModeTest.kt
@@ -69,35 +69,6 @@ class SessionDisplayGridModeTest {
     }
 
     // ========================================
-    // Protocol Tag Hiding Tests
-    // ========================================
-
-    @Test
-    fun testHideProtocolTagsDefaultState() {
-        assertTrue(
-            session.hideProtocolTags.value,
-            "Protocol tags should be hidden by default in grid view",
-        )
-    }
-
-    @Test
-    fun testToggleProtocolTagsVisibility() {
-        assertTrue(session.hideProtocolTags.value)
-
-        session.toggleHideProtocolTags()
-        assertFalse(
-            session.hideProtocolTags.value,
-            "Protocol tags should be visible after toggle",
-        )
-
-        session.toggleHideProtocolTags()
-        assertTrue(
-            session.hideProtocolTags.value,
-            "Protocol tags should be hidden again after second toggle",
-        )
-    }
-
-    // ========================================
     // Grid Mode Message Display Tests
     // ========================================
 

--- a/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/ui/MessageDetailPanelIntegrationTest.kt
+++ b/composeApp/src/jvmTest/kotlin/com/knapsack/fixtool/ui/MessageDetailPanelIntegrationTest.kt
@@ -215,29 +215,6 @@ class MessageDetailPanelIntegrationTest {
     }
 
     @Test
-    fun testProtocolTagToggleButtonExists() {
-        // Given: A Quote Request message
-        val quoteRequest = createQuoteRequest()
-
-        // When: MessageDetailPanel is displayed
-        composeTestRule.setContent {
-            MessageDetailPanel(
-                message = quoteRequest,
-                dictionary = dictionary,
-                onClose = { closeCallCount++ },
-            )
-        }
-
-        // Then: The protocol tag visibility toggle button should be displayed
-        // (Either "Show Protocol Tags" or "Hide Protocol Tags" depending on initial state)
-        try {
-            composeTestRule.onNodeWithContentDescription("Show Protocol Tags").assertExists()
-        } catch (e: AssertionError) {
-            composeTestRule.onNodeWithContentDescription("Hide Protocol Tags").assertExists()
-        }
-    }
-
-    @Test
     fun testExpandCollapseAllButtonExists() {
         // Given: A Quote Request with repeating groups
         val quoteRequest = createQuoteRequest()


### PR DESCRIPTION
Problem: Protocol tags visibility was implemented as per-session and per-component state, causing confusion for users who expected consistent behavior across all sessions. Each session and the message detail panel had separate toggle buttons, making it unclear whether the setting would apply globally or locally. This added unnecessary complexity to the codebase with duplicated state management across multiple components.

Changes:

AppSettings and ViewModel:
- Rename hideProtocolTagsByDefault to hideProtocolTags in AppSettings
- Remove per-session hideProtocolTags StateFlow from FixMessageSession
- Remove toggleHideProtocolTags() function from FixMessageSession
- Add toggleHideProtocolTags() function to FixMessageViewModel
- ViewModel function updates global AppSettings and persists to disk

UI Components - Add Global Control:
- Add hideProtocolTags parameter to Toolbar component
- Add onToggleHideProtocolTags callback to Toolbar
- Add global toggle button in Toolbar with Visibility/VisibilityOff icons
- Wire up Toolbar callback to ViewModel.toggleHideProtocolTags()
- Pass appSettings.hideProtocolTags to Toolbar for current state

UI Components - Remove Local Controls:
- Remove hideProtocolTags state collection from SplitView session toolbar
- Remove protocol tags toggle button from SplitView (was at line 416-432)
- Remove hideProtocolTags local state from MessageDetailPanel
- Remove protocol tags toggle button from MessageDetailPanel header
- Remove unused hideProtocolTags collection from TabBar

UI Components - Update References:
- Update SplitView FixMessageDisplay to use appSettings.hideProtocolTags
- Update App.kt FixMessageDisplay to use viewModel.appSettings.hideProtocolTags
- Update MessageDetailPanel renderQuickFixMessage to use appSettings.hideProtocolTags
- Update SettingsDialog to use renamed hideProtocolTags property

Tests:
- Remove obsolete per-session protocol tags tests from SessionDisplayGridModeTest
- Remove testProtocolTagToggleButtonExists from MessageDetailPanelIntegrationTest
- All remaining tests pass with new global setting architecture

Benefits:
- Simpler UX: Single global control instead of multiple per-session controls
- Consistent behavior: All sessions and components use the same setting
- Cleaner code: Eliminated per-session state management and toggle logic
- Better discoverability: Global toggle is prominently placed in main toolbar
- Reduced cognitive load: Users no longer confused about scope of the setting
- Easier maintenance: Single source of truth for protocol tags visibility

## Description

<!-- Provide a clear and concise description of what this PR does -->

## Type of Change

Please check the type of change your PR introduces:

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ✅ Test improvements

## Related Issues

<!-- Link to related issues using #issue-number -->

Fixes #
Relates to #

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe how you tested these changes -->

### Test Coverage

- [ ] Integration tests added
- [ ] E2E tests added (if applicable)
- [ ] Unit tests added (if applicable)
- [ ] All tests pass locally
- [ ] Tested manually (describe scenarios below)

**Manual Testing:**
<!-- Describe manual testing performed -->


## Screenshots / Videos

<!-- If applicable, add screenshots or videos demonstrating the changes -->

## Checklist

Please ensure your PR meets these requirements:

### Code Quality

- [ ] Code follows the project's style guidelines
- [ ] `./gradlew ktlintFormat` run to format code
- [ ] `./gradlew detekt` passes with no issues
- [ ] `./gradlew jvmTest` passes all tests
- [ ] Unused code and debug statements removed
- [ ] No commented-out code

### Documentation

- [ ] README.md updated (if needed)
- [ ] KDoc comments added for public APIs
- [ ] CONTRIBUTING.md guidelines followed
- [ ] Test data uses generic values (no secrets/org-specific data)

### Git

- [ ] Working on a feature branch (not main)
- [ ] Commit messages are clear and follow [conventional format](CONTRIBUTING.md#5-commit-your-changes)
- [ ] No mentions of AI tools or test status in commit messages
- [ ] Branch is up to date with main

### Security

- [ ] No secrets, credentials, or API keys committed
- [ ] Test data uses generic values only
- [ ] No organization-specific information included

## AI-Assisted Development

If you used AI tools (Claude Code, GitHub Copilot, etc.) to assist with this PR:

- [ ] I have reviewed all AI-generated code
- [ ] I followed the [AI guidelines](.ai-guidelines.md)
- [ ] Commit messages don't mention AI tools

## Additional Notes

<!-- Any additional information or context about this PR -->

---

**For Maintainers:**

- [ ] Code review completed
- [ ] Tests verified
- [ ] Documentation checked
- [ ] Ready to merge
